### PR TITLE
fix: Evaluate retryCondition for transient network-level errors

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,4 +1,4 @@
 fileignoreconfig:
 - filename: package-lock.json
-  checksum: c573bb4a5846055335df856bff87f28d9fccb90714ac4dbd699f5dcff2257615
+  checksum: ddc9d834376cbb1d8685c05b045a416e78494207f70403838d6d0d8a998dcf2f
 version: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change log
 
+### Version: 1.4.0
+#### Date: May-25-2026
+ - Fix: Evaluate `retryCondition` for transient network-level errors (e.g. `ETIMEDOUT`, `ECONNRESET`, `EPIPE`) that have no HTTP response, so configured retry policies apply without external axios interceptors
+ - Fix: Honor `retryDelayOptions.customBackoff` in the delivery SDK retry delay path (network retries, `retryCondition` retries, and 429/401 retries)
+
 ### Version: 1.3.14
 #### Date: May-04-2026
  - Fix: Bump axios to ^1.15.2 (security patches for axios 1.15.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@contentstack/core",
-  "version": "1.3.14",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@contentstack/core",
-      "version": "1.3.14",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.15.2",
         "axios-mock-adapter": "^2.1.0",
         "lodash": "^4.18.1",
-        "qs": "6.15.1",
+        "qs": "6.15.2",
         "tslib": "^2.8.1"
       },
       "devDependencies": {
@@ -2469,32 +2469,10 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
-      }
-    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2608,9 +2586,9 @@
       "license": "MIT"
     },
     "node_modules/@types/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2688,9 +2666,9 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2817,9 +2795,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2857,9 +2835,9 @@
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2888,9 +2866,9 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3158,13 +3136,15 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3565,13 +3545,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3726,9 +3707,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3960,9 +3941,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -4048,9 +4029,9 @@
       "license": "MIT"
     },
     "node_modules/clear-module": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
-      "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.3.tgz",
+      "integrity": "sha512-XdLrg7BnbXKntyrbs2dNjDN9CVoTQ+WV0i7jT5/r9ahzAaSDSzC9e2OVZB/QVwbxBb1/1AeObzjlxsYk5HFvww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4839,7 +4820,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5103,9 +5083,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.349",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "version": "1.5.360",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+      "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
       "dev": true,
       "license": "ISC"
     },
@@ -5657,9 +5637,9 @@
       }
     },
     "node_modules/eslint-plugin-functional/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6207,9 +6187,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6441,9 +6421,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7017,18 +6997,27 @@
         "node": ">= 14"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.2",
+        "agent-base": "6",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {
@@ -7384,13 +7373,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7946,9 +7935,9 @@
       }
     },
     "node_modules/istanbul-lib-report/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8782,9 +8771,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8953,6 +8942,30 @@
         "canvas": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/jsesc": {
@@ -9551,7 +9564,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -9655,11 +9667,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.45",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.45.tgz",
+      "integrity": "sha512-iIbHXV9eBB2nB0wa7oTsrrXq+qQt+9SIlx9AX3T96YgobtEQfis5n6TJ6vV+3QP8DwdriEAcGhARaFCu37peBg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
@@ -9678,9 +9693,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10330,9 +10345,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -10673,14 +10688,14 @@
       }
     },
     "node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -11577,9 +11592,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.46.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+      "version": "5.47.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+      "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -11596,9 +11611,9 @@
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.5.0.tgz",
-      "integrity": "sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.6.0.tgz",
+      "integrity": "sha512-Eum+5ajkaOhf5KbM26osvv21kLD7BaGqQ1UA4Ami4arYwylmGUQTgHFpHDdmJod1q4QXa66p0to/FBKID+J1vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11618,10 +11633,37 @@
         "webpack": "^5.1.0"
       },
       "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
         "@swc/core": {
           "optional": true
         },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
         "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
           "optional": true
         },
         "uglify-js": {
@@ -11854,9 +11896,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -11898,9 +11940,9 @@
       }
     },
     "node_modules/ts-loader/node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11912,9 +11954,9 @@
       }
     },
     "node_modules/ts-loader/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -12401,13 +12443,12 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.106.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
-      "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
+      "version": "5.107.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.107.0.tgz",
+      "integrity": "sha512-PSxeHk/dmLYZlnTU+vL1Gej6Evg5RNtl3flhxBresfznFnzxinHMzHKloHnywM/3ouQv7/AlZCswWDIkNSggUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
@@ -12417,20 +12458,20 @@
         "acorn-import-phases": "^1.0.3",
         "browserslist": "^4.28.1",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.20.0",
-        "es-module-lexer": "^2.0.0",
+        "enhanced-resolve": "^5.21.4",
+        "es-module-lexer": "^2.1.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.2.11",
-        "loader-runner": "^4.3.1",
+        "loader-runner": "^4.3.2",
         "mime-db": "^1.54.0",
         "neo-async": "^2.6.2",
         "schema-utils": "^4.3.3",
         "tapable": "^2.3.0",
-        "terser-webpack-plugin": "^5.3.17",
+        "terser-webpack-plugin": "^5.5.0",
         "watchpack": "^2.5.1",
-        "webpack-sources": "^3.3.4"
+        "webpack-sources": "^3.4.1"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -12542,9 +12583,9 @@
       }
     },
     "node_modules/webpack/node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12792,9 +12833,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentstack/core",
-  "version": "1.3.14",
+  "version": "1.4.0",
   "type": "commonjs",
   "main": "./dist/cjs/src/index.js",
   "types": "./dist/cjs/src/index.d.ts",
@@ -36,7 +36,7 @@
     "axios": "^1.15.2",
     "axios-mock-adapter": "^2.1.0",
     "lodash": "^4.18.1",
-    "qs": "6.15.1",
+    "qs": "6.15.2",
     "tslib": "^2.8.1"
   },
   "files": [

--- a/src/lib/retryPolicy/delivery-sdk-handlers.ts
+++ b/src/lib/retryPolicy/delivery-sdk-handlers.ts
@@ -15,6 +15,24 @@ const defaultConfig = {
   retryDelay: 300,
 };
 
+const DEFAULT_RETRY_DELAY_MS = 300;
+
+/**
+ * Resolve retry delay from customBackoff, configured retryDelay, or default.
+ */
+export const getRetryDelay = (config: any): number => {
+  if (config.retryDelayOptions?.customBackoff) {
+    return config.retryDelayOptions.customBackoff();
+  }
+
+  const retryDelay = config.retryDelay;
+  if (retryDelay) {
+    return retryDelay;
+  }
+
+  return DEFAULT_RETRY_DELAY_MS;
+};
+
 export const retryRequestHandler = (req: InternalAxiosRequestConfig<any>): InternalAxiosRequestConfig<any> => {
   req.retryCount = req.retryCount || 1;
 
@@ -34,6 +52,12 @@ export const retryResponseErrorHandler = (error: any, config: any, axiosInstance
 
     const response = error.response;
     if (!response) {
+      if (config.retryCondition && config.retryCondition(error)) {
+        retryCount++;
+
+        return retry(error, config, retryCount, getRetryDelay(config), axiosInstance);
+      }
+
       if (error.code === 'ECONNABORTED') {
         const customError = {
           error_message: ERROR_MESSAGES.RETRY.TIMEOUT_EXCEEDED(config.timeout),
@@ -41,67 +65,67 @@ export const retryResponseErrorHandler = (error: any, config: any, axiosInstance
           errors: null,
         };
         throw customError; // Throw customError object
-      } else {
-        throw error;
       }
-    } else {
-      const rateLimitRemaining = response.headers['x-ratelimit-remaining'];
 
-      // Handle rate limit exhaustion with retry logic
-      if (rateLimitRemaining !== undefined && parseInt(rateLimitRemaining) <= 0) {
-        retryCount++;
+      throw error;
+    }
 
-        if (retryCount >= config.retryLimit) {
+    const rateLimitRemaining = response.headers['x-ratelimit-remaining'];
+
+    // Handle rate limit exhaustion with retry logic
+    if (rateLimitRemaining !== undefined && parseInt(rateLimitRemaining) <= 0) {
+      retryCount++;
+
+      if (retryCount >= config.retryLimit) {
+        return Promise.reject(error.response.data);
+      }
+
+      error.config.retryCount = retryCount;
+
+      // Calculate delay for rate limit reset
+      const rateLimitResetDelay = calculateRateLimitDelay(response.headers);
+
+      return new Promise((resolve, reject) => {
+        setTimeout(async () => {
+          try {
+            const retryResponse = await axiosInstance(error.config);
+            resolve(retryResponse);
+          } catch (retryError) {
+            reject(retryError);
+          }
+        }, rateLimitResetDelay);
+      });
+    }
+
+    if (response.status == 429 || response.status == 401) {
+      retryCount++;
+
+      if (retryCount >= config.retryLimit) {
+        if (error.response && error.response.data) {
           return Promise.reject(error.response.data);
         }
 
-        error.config.retryCount = retryCount;
-
-        // Calculate delay for rate limit reset
-        const rateLimitResetDelay = calculateRateLimitDelay(response.headers);
-
-        return new Promise((resolve, reject) => {
-          setTimeout(async () => {
-            try {
-              const retryResponse = await axiosInstance(error.config);
-              resolve(retryResponse);
-            } catch (retryError) {
-              reject(retryError);
-            }
-          }, rateLimitResetDelay);
-        });
+        return Promise.reject(error);
       }
+      error.config.retryCount = retryCount;
 
-      if (response.status == 429 || response.status == 401) {
-        retryCount++;
-
-        if (retryCount >= config.retryLimit) {
-          if (error.response && error.response.data) {
-            return Promise.reject(error.response.data);
+      // Apply configured delay for retries
+      return new Promise((resolve, reject) => {
+        setTimeout(async () => {
+          try {
+            const retryResponse = await axiosInstance(error.config);
+            resolve(retryResponse);
+          } catch (retryError) {
+            reject(retryError);
           }
-
-          return Promise.reject(error);
-        }
-        error.config.retryCount = retryCount;
-
-        // Apply configured delay for retries
-        return new Promise((resolve, reject) => {
-          setTimeout(async () => {
-            try {
-              const retryResponse = await axiosInstance(error.config);
-              resolve(retryResponse);
-            } catch (retryError) {
-              reject(retryError);
-            }
-          }, config.retryDelay || 300); // Use configured delay with fallback
-        });
-      }
+        }, getRetryDelay(config));
+      });
     }
 
     if (config.retryCondition && config.retryCondition(error)) {
       retryCount++;
 
-      return retry(error, config, retryCount, config.retryDelay, axiosInstance);
+      return retry(error, config, retryCount, getRetryDelay(config), axiosInstance);
     }
 
     throw error;
@@ -114,8 +138,7 @@ const retry = (error: any, config: any, retryCount: number, retryDelay: number, 
     return Promise.reject(error);
   }
 
-  // Use the passed retryDelay parameter first, then config.retryDelay, then default
-  const delayTime = retryDelay || config.retryDelay || 300;
+  const delayTime = retryDelay || getRetryDelay(config);
   error.config.retryCount = retryCount;
 
   return new Promise(function (resolve, reject) {

--- a/test/retryPolicy/delivery-sdk-handlers.spec.ts
+++ b/test/retryPolicy/delivery-sdk-handlers.spec.ts
@@ -5,6 +5,7 @@ import {
   retryResponseHandler,
   retryResponseErrorHandler,
   calculateRateLimitDelay,
+  getRetryDelay,
 } from '../../src/lib/retryPolicy/delivery-sdk-handlers';
 import MockAdapter from 'axios-mock-adapter';
 
@@ -72,6 +73,134 @@ describe('retryResponseErrorHandler', () => {
       expect(err).toEqual(error);
     }
   });
+  it('should retry network-level errors when retryCondition returns true', async () => {
+    const error = {
+      config: { retryOnError: true, retryCount: 1, method: 'get', url: '/network-retry' },
+      code: 'ETIMEDOUT',
+      message: 'connect ETIMEDOUT',
+    };
+    const retryCondition = jest.fn().mockReturnValue(true);
+    const config = { retryLimit: 3, retryCondition, retryDelay: 200 };
+    const client = axios.create();
+
+    mock.onGet('/network-retry').reply(200, { success: true });
+
+    jest.useFakeTimers();
+
+    const responsePromise = retryResponseErrorHandler(error, config, client);
+    jest.advanceTimersByTime(200);
+
+    const response = (await responsePromise) as AxiosResponse;
+    expect(response.status).toBe(200);
+    expect(retryCondition).toHaveBeenCalledWith(error);
+
+    jest.useRealTimers();
+  });
+
+  it('should retry ECONNRESET when retryCondition returns true', async () => {
+    const error = {
+      config: { retryOnError: true, retryCount: 1, method: 'get', url: '/conn-reset' },
+      code: 'ECONNRESET',
+      message: 'socket hang up',
+    };
+    const retryCondition = jest.fn().mockImplementation((err: any) => err.code === 'ECONNRESET');
+    const config = { retryLimit: 3, retryCondition, retryDelay: 150 };
+    const client = axios.create();
+
+    mock.onGet('/conn-reset').reply(200, { recovered: true });
+
+    jest.useFakeTimers();
+
+    const responsePromise = retryResponseErrorHandler(error, config, client);
+    jest.advanceTimersByTime(150);
+
+    const response = (await responsePromise) as AxiosResponse;
+    expect(response.data.recovered).toBe(true);
+
+    jest.useRealTimers();
+  });
+
+  it('should rethrow network errors when retryCondition returns false', async () => {
+    const error = {
+      config: { retryOnError: true, retryCount: 1 },
+      code: 'EPIPE',
+      message: 'write EPIPE',
+    };
+    const retryCondition = jest.fn().mockReturnValue(false);
+    const config = { retryLimit: 3, retryCondition };
+    const client = axios.create();
+
+    try {
+      await retryResponseErrorHandler(error, config, client);
+      fail('Expected retryResponseErrorHandler to throw the network error');
+    } catch (err) {
+      expect(err).toEqual(error);
+    }
+    expect(retryCondition).toHaveBeenCalledWith(error);
+  });
+
+  it('should retry ECONNABORTED when retryCondition returns true instead of throwing timeout error', async () => {
+    const error = {
+      config: { retryOnError: true, retryCount: 1, method: 'get', url: '/timeout-retry' },
+      code: 'ECONNABORTED',
+      message: 'timeout of 1000ms exceeded',
+    };
+    const retryCondition = jest.fn().mockReturnValue(true);
+    const config = { retryLimit: 3, timeout: 1000, retryCondition, retryDelay: 100 };
+    const client = axios.create();
+
+    mock.onGet('/timeout-retry').reply(200, { success: true });
+
+    jest.useFakeTimers();
+
+    const responsePromise = retryResponseErrorHandler(error, config, client);
+    jest.advanceTimersByTime(100);
+
+    const response = (await responsePromise) as AxiosResponse;
+    expect(response.status).toBe(200);
+    expect(retryCondition).toHaveBeenCalledWith(error);
+
+    jest.useRealTimers();
+  });
+
+  it('should use customBackoff for network-level retries when configured', async () => {
+    const error = {
+      config: { retryOnError: true, retryCount: 1, method: 'get', url: '/custom-backoff' },
+      code: 'ETIMEDOUT',
+      message: 'connect ETIMEDOUT',
+    };
+    const customBackoff = jest.fn().mockReturnValue(900);
+    const retryCondition = jest.fn().mockReturnValue(true);
+    const config = {
+      retryLimit: 3,
+      retryCondition,
+      retryDelay: 100,
+      retryDelayOptions: { base: 300, customBackoff },
+    };
+    const client = axios.create();
+
+    mock.onGet('/custom-backoff').reply(200, { success: true });
+
+    jest.useFakeTimers();
+
+    const responsePromise = retryResponseErrorHandler(error, config, client);
+    jest.advanceTimersByTime(899);
+    await Promise.resolve();
+
+    let settled = false;
+    responsePromise.then(() => {
+      settled = true;
+    });
+    expect(settled).toBe(false);
+
+    jest.advanceTimersByTime(1);
+    const response = (await responsePromise) as AxiosResponse;
+    expect(response.status).toBe(200);
+    expect(customBackoff).toHaveBeenCalled();
+
+    jest.useRealTimers();
+  });
+
   it('should resolve the promise to 408 error if retryOnError is true and error code is ECONNABORTED', async () => {
     const error = { config: { retryOnError: true, retryCount: 1 }, code: 'ECONNABORTED' };
     const config = { retryLimit: 5, timeout: 1000 };
@@ -1082,6 +1211,28 @@ describe('retryResponseErrorHandler', () => {
         content: ['Content cannot be empty'],
       });
     }
+  });
+});
+
+describe('getRetryDelay', () => {
+  it('should return customBackoff value when retryDelayOptions.customBackoff is set', () => {
+    const customBackoff = jest.fn().mockReturnValue(1200);
+    const config = {
+      retryDelay: 300,
+      retryDelayOptions: { base: 300, customBackoff },
+    };
+
+    expect(getRetryDelay(config)).toBe(1200);
+    expect(customBackoff).toHaveBeenCalled();
+  });
+
+  it('should return configured retryDelay when customBackoff is not set', () => {
+    expect(getRetryDelay({ retryDelay: 500 })).toBe(500);
+  });
+
+  it('should return default delay when retryDelay is unset or zero', () => {
+    expect(getRetryDelay({})).toBe(300);
+    expect(getRetryDelay({ retryDelay: 0 })).toBe(300);
   });
 });
 


### PR DESCRIPTION
**Summary**
Fixes Delivery SDK retry behavior for transient network-level failures and wires up retryDelayOptions.customBackoff in the core retry handler.

**Problem**
In retryResponseErrorHandler, errors without an HTTP response (error.response is undefined) were rethrown immediately. That skipped retryCondition, so codes like ETIMEDOUT, ECONNRESET, and EPIPE were never retried even when customers configured a custom retryCondition in StackConfig.

retryDelayOptions.customBackoff was exposed on HttpClientParams but not used when computing retry delays.

**Solution**

1. Evaluate retryCondition first for no-response errors; retry when it returns true.
2. Preserve existing ECONNABORTED behavior: still returns the 408-style timeout error when retryCondition does not apply.
3. Add getRetryDelay() to honor customBackoff → retryDelay → 300ms default for:

> Network-level retries via retryCondition

> retryCondition-driven HTTP error retries

> 429/401 retries
> (Rate-limit header delays via x-ratelimit-remaining / retry-after are unchanged.)

**Impact**

Improves reliability for long-lived connections behind proxies, load balancers, and CDNs, including intermittent timeouts reported on Azure, without requiring custom axios interceptors.

**Version**
1.4.0 — May 25, 2026

**Test plan**

 Unit tests for ETIMEDOUT, ECONNRESET, EPIPE, ECONNABORTED + retryCondition

 Unit tests for customBackoff delay

 Existing rate-limit (x-ratelimit-remaining) and 429/401 retry tests pass

 Publish @contentstack/core@1.4.0 and bump @contentstack/delivery-sdk dependency
